### PR TITLE
Rw course validation incl tests

### DIFF
--- a/Data/Entities/Evl.cs
+++ b/Data/Entities/Evl.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using HAN.Data.Entities.CourseComponents;
 
 namespace HAN.Data.Entities;
 
@@ -24,4 +25,7 @@ public class Evl : BaseEntity
     [Required]
     [DataType(DataType.DateTime)]
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    
+    public ICollection<Lesson> Lessons { get; set; } = new List<Lesson>();
+    public ICollection<Exam> Exams { get; set; } = new List<Exam>();
 }

--- a/HAN.Domain/Entities/Course.cs
+++ b/HAN.Domain/Entities/Course.cs
@@ -1,0 +1,30 @@
+﻿using HAN.Domain.Validation;
+
+namespace HAN.Domain.Entities;
+
+public class Course
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    
+    public ICollection<Evl> EVLs { get; set; } = new List<Evl>();
+    
+    public ValidationResult Validate()
+    {
+        if (EVLs.Count == 0)
+        {
+            return new ValidationResult(false, "A course must have at least one EVL.");
+        }
+
+        foreach (var evl in EVLs)
+        {
+            var evlValidation = evl.Validate();
+            if (!evlValidation.IsValid)
+            {
+                return evlValidation;
+            }
+        }
+
+        return ValidationResult.Valid();
+    }
+}

--- a/HAN.Domain/Entities/Evl.cs
+++ b/HAN.Domain/Entities/Evl.cs
@@ -1,0 +1,26 @@
+﻿
+using HAN.Domain.Validation;
+
+namespace HAN.Domain.Entities;
+
+public class Evl
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public ICollection<Lesson> Lessons { get; set; } = new List<Lesson>();
+    public ICollection<Exam> Exams { get; set; } = new List<Exam>();
+
+    public ValidationResult Validate()
+    {
+        if (Lessons.Count == 0)
+        {
+            return new ValidationResult(false, "An EVL must have at least one Lesson.");
+        }
+        if (Exams.Count == 0)
+        {
+            return new ValidationResult(false, "An EVL must have at least one Exam.");
+        }
+        return ValidationResult.Valid();
+    }
+}

--- a/HAN.Domain/Entities/Exam.cs
+++ b/HAN.Domain/Entities/Exam.cs
@@ -1,0 +1,6 @@
+﻿namespace HAN.Domain.Entities;
+
+public class Exam
+{
+    
+}

--- a/HAN.Domain/Entities/Lesson.cs
+++ b/HAN.Domain/Entities/Lesson.cs
@@ -1,0 +1,6 @@
+﻿namespace HAN.Domain.Entities;
+
+public class Lesson
+{
+    
+}

--- a/HAN.Domain/Validation/ValidationResult.cs
+++ b/HAN.Domain/Validation/ValidationResult.cs
@@ -1,0 +1,16 @@
+﻿namespace HAN.Domain.Validation;
+    
+public class ValidationResult
+{
+    public bool IsValid { get; private set; }
+    public string ErrorMessage { get; private set; }
+
+    public ValidationResult(bool isValid, string errorMessage = "")
+    {
+        IsValid = isValid;
+        ErrorMessage = errorMessage;
+    }
+
+    public static ValidationResult Valid() => new ValidationResult(true);
+    public static ValidationResult Invalid(string errorMessage) => new ValidationResult(false, errorMessage);
+}

--- a/HAN.Services/CourseService.cs
+++ b/HAN.Services/CourseService.cs
@@ -51,6 +51,4 @@ public class CourseService(ICourseRepository courseRepository, IEvlRepository ev
 
         courseRepository.AddEvlToCourse(courseId, evlId);
     }
-
-
 }

--- a/HAN.Services/CourseValidationService.cs
+++ b/HAN.Services/CourseValidationService.cs
@@ -1,0 +1,24 @@
+﻿using AutoMapper;
+using HAN.Domain.Entities;
+
+namespace HAN.Services;
+
+public interface ICourseValidationService
+{
+    public bool ValidateCourse(int courseId);    
+}
+
+public class CourseValidationService(ICourseService courseService, IMapper mapper) : ICourseValidationService
+{
+    public bool ValidateCourse(int courseId)
+    {
+        var course = courseService.GetCourseById(courseId);
+
+        if(course == null)
+            throw new KeyNotFoundException("Course with id {courseId} not found.");
+        
+        var courseDomainEntity = mapper.Map<Course>(course);
+
+        return courseDomainEntity.Validate().IsValid;
+    }
+}

--- a/HAN.Services/DTOs/CourseResponseDto.cs
+++ b/HAN.Services/DTOs/CourseResponseDto.cs
@@ -1,8 +1,11 @@
-﻿namespace HAN.Services.DTOs;
+﻿using HAN.Domain.Entities;
+
+namespace HAN.Services.DTOs;
 
 public class CourseResponseDto
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+    public IEnumerable<Evl> Evls { get; set; } = new List<Evl>();
 }

--- a/HAN.Services/Mappers/CourseProfile.cs
+++ b/HAN.Services/Mappers/CourseProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using HAN.Data.Entities;
+using HAN.Data.Entities.CourseComponents;
 using HAN.Services.DTOs;
 
 namespace HAN.Services.Mappers;
@@ -12,15 +13,20 @@ public class CourseProfile : Profile
         
         // Persistence
         CreateMap<CreateCourseDto, Course>();
-        CreateMap<Course, CourseResponseDto>();
+        CreateMap<Data.Entities.Course, CourseResponseDto>();
+        CreateMap<CourseResponseDto, Domain.Entities.Course>();
         
         CreateMap<CreateCourseComponentDto, CourseComponent>();
         CreateMap<CourseComponent, CourseComponentResponseDto>();
         
         CreateMap<CreateEvlDto, Evl>();
+        CreateMap<Evl, Domain.Entities.Evl>();
         CreateMap<Evl, EvlResponseDto>();
         
         CreateMap<CreateUserDto, User>();
         CreateMap<User, UserResponseDto>();
+
+        CreateMap<Lesson, Domain.Entities.Lesson>();
+        CreateMap<Exam, Domain.Entities.Exam>();
     }
 }

--- a/HAN.Tests/Base/DbEntityGenerator.cs
+++ b/HAN.Tests/Base/DbEntityGenerator.cs
@@ -68,7 +68,13 @@ public static class DbEntityCreator<T> where T : class, new()
         {
             return GenerateBoolean();
         }
-
+        
+        // List, instanciate new list
+        if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(List<>))
+        {
+            return Activator.CreateInstance(propertyType);
+        }
+        
         // Add more types if needed (e.g., float, double, etc.)
         return null;
     }

--- a/HAN.Tests/Base/TestDbSeeder.cs
+++ b/HAN.Tests/Base/TestDbSeeder.cs
@@ -8,21 +8,6 @@ namespace HAN.Tests.Base;
 
 public static class TestDbSeeder
 {
-    public static void SeedUsers(AppDbContext context, int seedUserCount, string userPrefix)
-    {
-        var users = Enumerable.Range(0, seedUserCount)
-            .Select(i => {
-                var user = DbEntityCreator<User>.CreateEntity();
-                user.Name = $"{userPrefix}{i + 1}";
-                user.Email = $"{userPrefix}{i + 1}@coursegenerator.com";
-                return user;
-            })
-            .ToList();
-
-        context.Users.AddRange(users);
-        context.SaveChanges();
-    }
-
     public static void SeedCourses(AppDbContext context, int seedCourseCount)
     {
         var courses = Enumerable.Range(0, seedCourseCount)
@@ -43,37 +28,6 @@ public static class TestDbSeeder
         context.SaveChanges();
 
         return evls;
-    }
-    
-    private static List<Evl> SeedEvlsWithCourseComponents(AppDbContext context, int seedEvlCount)
-    {
-        var evls = SeedEvls(context, seedEvlCount);
-        
-        evls.SeedCourseComponentsForEvls(context);
-
-        context.SaveChanges();
-
-        return evls;
-    }
-    
-
-    private static void SeedCourseComponentsForEvls(this List<Evl> evls, AppDbContext context)
-    {
-        evls.ForEach(evl =>
-        {
-            var courseComponent = DbEntityCreator<CourseComponent>.CreateEntity();
-
-            context.CourseComponents.Add(courseComponent);
-            context.SaveChanges();
-
-            courseComponent = context.CourseComponents
-                .Include(c => c.Evls)
-                .Single(c => c.Id == courseComponent.Id);
-
-            courseComponent.Evls.Add(evl);
-        });
-        
-        context.SaveChanges();
     }
     
     public static void SeedCourseComponents(AppDbContext context, int seedCourseComponentCount)

--- a/HAN.Tests/Base/TestDbSeeder.cs
+++ b/HAN.Tests/Base/TestDbSeeder.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.Design;
 using HAN.Data;
 using HAN.Data.Entities;
+using HAN.Data.Entities.CourseComponents;
 using Microsoft.EntityFrameworkCore;
 
 namespace HAN.Tests.Base;
@@ -31,25 +32,6 @@ public static class TestDbSeeder
         context.Courses.AddRange(courses);
         context.SaveChanges();
     }
-    
-    public static void SeedCoursesForValidation(AppDbContext context, int seedCourseCount)
-    {
-        SeedCourses(context, seedCourseCount);
-
-        var courses = context.Courses
-            .Include(c => c.Evls)
-            .ToList();
-
-        courses.AddEvlsToCources(context, seedCourseCount);
-        
-        context.SaveChanges();
-    }
-
-    private static void AddEvlsToCources(this List<Course> courses, AppDbContext context, int seedEvlsCount) => 
-        courses.ForEach(course =>
-            SeedEvlsWithCourseComponents(context, seedEvlsCount)
-                .ForEach(ev => course.Evls.Add(ev)
-        ));
 
     public static List<Evl> SeedEvls(AppDbContext context, int seedEvlCount)
     {
@@ -73,6 +55,7 @@ public static class TestDbSeeder
 
         return evls;
     }
+    
 
     private static void SeedCourseComponentsForEvls(this List<Evl> evls, AppDbContext context)
     {

--- a/HAN.Tests/Base/TestDbSeederValidateCourse.cs
+++ b/HAN.Tests/Base/TestDbSeederValidateCourse.cs
@@ -1,0 +1,115 @@
+﻿using HAN.Data;
+using HAN.Data.Entities;
+using HAN.Data.Entities.CourseComponents;
+using Microsoft.EntityFrameworkCore;
+
+namespace HAN.Tests.Base;
+
+public static class TestDbSeederValidateCourse
+{
+    public static int SeedValidCourseForValidation(AppDbContext context)
+    {
+        const int totalCourses = 1;
+        const int validCourseId = 1;
+        
+        TestDbSeeder.SeedCourses(context, totalCourses);
+
+        var courses = context.Courses
+            .Include(c => c.Evls)
+            .ToList();
+
+        courses.AddValidEvlsToCources(context, totalCourses);
+        
+        context.SaveChanges();
+
+        return validCourseId;
+    }
+    
+    public static int SeedInvalidLessonCourseForValidation(AppDbContext context)
+    {
+        const int totalCourses = 1;
+        const int validCourseId = 1;
+        
+        TestDbSeeder.SeedCourses(context, totalCourses);
+
+        var courses = context.Courses
+            .Include(c => c.Evls)
+            .ToList();
+
+        courses.AddInvalidLessonsEvlsToCources(context, totalCourses);
+        
+        context.SaveChanges();
+
+        return validCourseId;
+    }
+    
+    private static void AddValidEvlsToCources(this List<Course> courses, AppDbContext context, int seedEvlsCount)
+    {
+        courses.ForEach(course =>
+            SeedLessonsAndExamsForEvls(context, seedEvlsCount)
+                .ForEach(ev => course.Evls.Add(ev)
+                ));
+        
+        context.SaveChanges();
+    }
+    
+    private static void AddInvalidLessonsEvlsToCources(this List<Course> courses, AppDbContext context, int seedEvlsCount)
+    {
+        courses.ForEach(course =>
+            SeedInvalidLessonsAndExamsForEvls(context, seedEvlsCount)
+                .ForEach(ev => course.Evls.Add(ev)
+                ));
+        
+        context.SaveChanges();
+    }
+    
+    public static List<Evl> SeedLessonsAndExamsForEvls(AppDbContext context, int seedEvlCount)
+    {
+        var evls = TestDbSeeder.SeedEvls(context, seedEvlCount);
+        
+        evls.SeedLessonAndExamForEvls(context);
+
+        return evls;
+    }
+    
+    public static List<Evl> SeedInvalidLessonsAndExamsForEvls(AppDbContext context, int seedEvlCount)
+    {
+        var evls = TestDbSeeder.SeedEvls(context, seedEvlCount);
+        
+        evls.SeedMissingLessonAndExamForEvls(context);
+
+        return evls;
+    }
+    
+    private static void SeedMissingLessonAndExamForEvls(this List<Evl> evls, AppDbContext context)
+    {
+        evls.ForEach(evl =>
+        {
+            var exam = DbEntityCreator<Exam>.CreateEntity();
+            evl.Exams ??= new List<Exam>();
+            evl.Exams.Add(exam);
+        });
+        
+        context.SaveChanges();
+    }
+    
+    private static void SeedLessonAndExamForEvls(this List<Evl> evls, AppDbContext context)
+    {
+        evls.ForEach(evl =>
+        {
+            var lesson = DbEntityCreator<Lesson>.CreateEntity();
+            var exam = DbEntityCreator<Exam>.CreateEntity();
+
+            evl.Exams ??= new List<Exam>();
+            evl.Lessons ??= new List<Lesson>();            
+            
+            evl.Lessons.Add(lesson);
+            evl.Exams.Add(exam);
+        });
+        
+        context.SaveChanges();
+    }
+    
+    
+    
+}

--- a/HAN.Tests/Base/TestServiceProvider.cs
+++ b/HAN.Tests/Base/TestServiceProvider.cs
@@ -2,6 +2,7 @@
 using HAN.Data.Entities;
 using HAN.Repositories;
 using HAN.Repositories.Interfaces;
+using HAN.Services;
 using HAN.Services.Extensions;
 using HAN.Tests.Mocks;
 using Microsoft.EntityFrameworkCore;
@@ -25,6 +26,7 @@ public static class TestServiceProvider
         services.AddScoped<ICourseRepository, CourseRepository>();
         services.AddScoped<ICourseComponentRepository, CourseComponentRepository>();
         services.AddScoped<IGenericRepository<ExampleEntity>, ExampleGenericRepository>();
+        services.AddScoped<ICourseValidationService, CourseValidationService>();
         services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
         
         services.AddCourseServices();

--- a/HAN.Tests/Services/CourseValidationTests.cs
+++ b/HAN.Tests/Services/CourseValidationTests.cs
@@ -1,29 +1,61 @@
 ﻿using HAN.Services;
+using HAN.Services.DTOs;
 using HAN.Tests.Base;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace HAN.Tests.Services;
 
 public class CourseValidationTests : TestBase
 {
-    private readonly ICourseService _courseService;
+    private readonly ICourseValidationService _courseValidationService;
     
-    public CourseValidationTests(ICourseService courseService)
+    public CourseValidationTests()
     {
-        _courseService = courseService;
-        //TestDbSeeder.SeedCoursesForValidation(Context, 2);
+        _courseValidationService = ServiceProvider.GetRequiredService<ICourseValidationService>();
     }
 
     [Fact]
     public void ValidateCourse_ShouldReturnTrue()
     {
-        throw new NotImplementedException();
-        // Arrange
+        var validCourseId = TestDbSeederValidateCourse.SeedValidCourseForValidation(Context);
+        var valid = _courseValidationService.ValidateCourse(validCourseId);
         
+        Assert.True(valid);
+    }
+    
+    [Fact]
+    public void ValidateCourse_ShouldReturnFalse()
+    {
+        var invalidCourseId = TestDbSeederValidateCourse.SeedInvalidLessonCourseForValidation(Context);
+        var valid = _courseValidationService.ValidateCourse(invalidCourseId);
         
-        // Act
+        Assert.False(valid);
+    }
+    
+    [Fact]
+    public void ValidateCourse_ShouldReturnFalse_WhenCourseDoesNotExist()
+    {
+        const int nonExistentCourse = 1000;
+        var valid = false;
         
+        var expectedException = Record.Exception(() =>
+        {
+            valid = _courseValidationService.ValidateCourse(nonExistentCourse);
+        });
+
+        Assert.NotNull(expectedException);
+        Assert.IsType<KeyNotFoundException>(expectedException);
+        Assert.False(valid);
+    }
+    
+    [Fact]
+    public void ValidateCourse_ShouldReturnFalse_WhenCourseHasNoEvls()
+    {
+        TestDbSeeder.SeedCourses(Context, 1);
+        const int courseId = 1;
         
-        // Assert
-        Assert.True(true);
+        var valid = _courseValidationService.ValidateCourse(courseId);
+        
+        Assert.False(valid);
     }
 }

--- a/HAN.Tests/Services/EvlServiceTests.cs
+++ b/HAN.Tests/Services/EvlServiceTests.cs
@@ -12,7 +12,6 @@ public class EvlServiceTests: TestBase
     public EvlServiceTests()
     {
         _evlService = ServiceProvider.GetRequiredService<IEvlService>();
-        TestDbSeeder.SeedCoursesForValidation(Context, 2);
     }
 
     [Fact]


### PR DESCRIPTION
Added extra logic.

For this, some concern identification was necessary:
- **Validation**

**Approach**: Domain-driven design
**Solution**: Make the domain object responsible for validation it's own data. Since the exams and lessons are attached to the domain object, the object itself can perform validation logic.

For the future, it might be good to remove the data annotations from the data entities. Now, the persistence concerns is cluttered with domain validation rules. I'd say it'd be better to store those rules within the domain layer instead, and only keep the persistence concerns at the data entities.